### PR TITLE
Added custom Session key name setting

### DIFF
--- a/src/Edi.Captcha.Tests/CaptchaImageMiddlewareTests.cs
+++ b/src/Edi.Captcha.Tests/CaptchaImageMiddlewareTests.cs
@@ -111,12 +111,12 @@ namespace Edi.Captcha.Tests
             var middleware = new CaptchaImageMiddleware(app);
 
             _captchaMock.Setup(p =>
-                p.GenerateCaptchaImageBytes(It.IsAny<ISession>(), It.IsAny<int>(), It.IsAny<int>()))
+                p.GenerateCaptchaImageBytes(It.IsAny<ISession>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
                 .Returns(Array.Empty<byte>());
 
             await middleware.Invoke(httpContextMock.Object, _captchaMock.Object);
 
-            _captchaMock.Verify(p => p.GenerateCaptchaImageBytes(It.IsAny<ISession>(), It.IsAny<int>(), It.IsAny<int>()));
+            _captchaMock.Verify(p => p.GenerateCaptchaImageBytes(It.IsAny<ISession>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()));
         }
     }
 }

--- a/src/Edi.Captcha/ISessionBasedCaptcha.cs
+++ b/src/Edi.Captcha/ISessionBasedCaptcha.cs
@@ -5,10 +5,10 @@ namespace Edi.Captcha
 {
     public interface ISessionBasedCaptcha
     {
-        byte[] GenerateCaptchaImageBytes(ISession httpSession, int width = 100, int height = 36);
+        byte[] GenerateCaptchaImageBytes(ISession httpSession, int width = 100, int height = 36, string sessionKeyName = null);
 
-        FileStreamResult GenerateCaptchaImageFileStream(ISession httpSession, int width = 100, int height = 36);
+        FileStreamResult GenerateCaptchaImageFileStream(ISession httpSession, int width = 100, int height = 36, string sessionKeyName = null);
 
-        bool Validate(string userInputCaptcha, ISession httpSession, bool ignoreCase = true, bool dropSession = true);
+        bool Validate(string userInputCaptcha, ISession httpSession, bool ignoreCase = true, bool dropSession = true, string sessionKeyName = null);
     }
 }

--- a/src/Edi.Captcha/SessionBasedCaptcha.cs
+++ b/src/Edi.Captcha/SessionBasedCaptcha.cs
@@ -24,23 +24,23 @@ namespace Edi.Captcha
 
         public abstract string GenerateCaptchaCode();
 
-        public byte[] GenerateCaptchaImageBytes(ISession httpSession, int width = 100, int height = 36)
+        public byte[] GenerateCaptchaImageBytes(ISession httpSession, int width = 100, int height = 36, string sessionKeyName = null)
         {
             EnsureHttpSession(httpSession);
 
             var captchaCode = GenerateCaptchaCode();
             var result = CaptchaImageGenerator.GetImage(width, height, captchaCode, Options.FontName, Options.FontStyle);
-            httpSession.SetString(Options.SessionName, result.CaptchaCode);
+            httpSession.SetString(sessionKeyName ?? Options.SessionName, result.CaptchaCode);
             return result.CaptchaByteData;
         }
 
-        public FileStreamResult GenerateCaptchaImageFileStream(ISession httpSession, int width = 100, int height = 36)
+        public FileStreamResult GenerateCaptchaImageFileStream(ISession httpSession, int width = 100, int height = 36, string sessionKeyName = null)
         {
             EnsureHttpSession(httpSession);
 
             var captchaCode = GenerateCaptchaCode();
             var result = CaptchaImageGenerator.GetImage(width, height, captchaCode, Options.FontName, Options.FontStyle);
-            httpSession.SetString(Options.SessionName, result.CaptchaCode);
+            httpSession.SetString(sessionKeyName ?? Options.SessionName, result.CaptchaCode);
             Stream s = new MemoryStream(result.CaptchaByteData);
             return new FileStreamResult(s, "image/png");
         }
@@ -53,17 +53,17 @@ namespace Edi.Captcha
         /// <param name="ignoreCase">Ignore Case (default = true)</param>
         /// <param name="dropSession">Whether to drop session regardless of the validation pass or not (default = true)</param>
         /// <returns>Is Valid Captcha Challenge</returns>
-        public bool Validate(string userInputCaptcha, ISession httpSession, bool ignoreCase = true, bool dropSession = true)
+        public bool Validate(string userInputCaptcha, ISession httpSession, bool ignoreCase = true, bool dropSession = true, string sessionKeyName = null)
         {
             if (string.IsNullOrWhiteSpace(userInputCaptcha))
             {
                 return false;
             }
-            var codeInSession = httpSession.GetString(Options.SessionName);
+            var codeInSession = httpSession.GetString(sessionKeyName ?? Options.SessionName);
             var isValid = string.Compare(userInputCaptcha, codeInSession, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
             if (dropSession)
             {
-                httpSession.Remove(Options.SessionName);
+                httpSession.Remove(sessionKeyName ?? Options.SessionName);
             }
             return isValid == 0;
         }


### PR DESCRIPTION
Hi, some time ago I added a possibility to set a custom session key:

```csharp
_captcha.GenerateCaptchaImageFileStream(
                _httpContextAccessor.HttpContext.Session,
                100,
                36,
                "MyCustomSessionKeyId");
```

It might be useful when you need to identify the captcha control is some specific or custom way.
If that's fine, I suggest merging it into the main branch. It's rather a safe change :)