### PR TITLE
set default font name for macOS

### DIFF
--- a/src/Edi.Captcha/CaptchaServiceCollectionExtensions.cs
+++ b/src/Edi.Captcha/CaptchaServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class CaptchaServiceCollectionExtensions
     public static void AddSessionBasedCaptcha(this IServiceCollection services, Action<BasicLetterCaptchaOptions> options = null)
     {
         string fontName = string.Empty;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             fontName = "Arial";
         }


### PR DESCRIPTION
https://github.com/EdiWang/Moonglade uses this project and it failed to run on macOS.
```bash
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      SixLabors.Fonts.FontFamilyNotFoundException: The "" font family could not be found
         at SixLabors.Fonts.FontCollection.GetImpl(String name, CultureInfo culture)
         at SixLabors.Fonts.FontCollection.Get(String name)
         at SixLabors.Fonts.SystemFontCollection.Get(String name)
         at SixLabors.Fonts.SystemFonts.CreateFont(String name, Single size, FontStyle style)
         at Edi.Captcha.CaptchaImageGenerator.GetImage(Int32 width, Int32 height, String captchaCode, String fontName, FontStyle fontStyle)
         at Edi.Captcha.SessionBasedCaptcha.GenerateCaptchaImageBytes(ISession httpSession, Int32 width, Int32 height, String sessionKeyName)
         at Edi.Captcha.CaptchaImageMiddleware.Invoke(HttpContext context, ISessionBasedCaptcha captcha)
2
         at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware: Error: An unhandled exception has occurred while executing the request.

SixLabors.Fonts.FontFamilyNotFoundException: The "" font family could not be found
   at SixLabors.Fonts.FontCollection.GetImpl(String name, CultureInfo culture)
   at SixLabors.Fonts.FontCollection.Get(String name)
   at SixLabors.Fonts.SystemFontCollection.Get(String name)
   at SixLabors.Fonts.SystemFonts.CreateFont(String name, Single size, FontStyle style)
   at Edi.Captcha.CaptchaImageGenerator.GetImage(Int32 width, Int32 height, String captchaCode, String fontName, FontStyle fontStyle)
   at Edi.Captcha.SessionBasedCaptcha.GenerateCaptchaImageBytes(ISession httpSession, Int32 width, Int32 height, String sessionKeyName)
   at Edi.Captcha.CaptchaImageMiddleware.Invoke(HttpContext context, ISessionBasedCaptcha captcha)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```
Although one possible fix is to set it explicitly by Moonglade when it adding this as a service, 
I think tt is better to make it support macOS by default

Signed-off-by: hoyho <luohaihao@gmail.com>