### PR TITLE
Remove some hard-to-tell characters by default.

### DIFF
--- a/src/Edi.Captcha/CaptchaServiceCollectionExtensions.cs
+++ b/src/Edi.Captcha/CaptchaServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class CaptchaServiceCollectionExtensions
 
         var option = new BasicLetterCaptchaOptions
         {
-            Letters = "2346789ABCDEFGHJKLMNPRTUVWXYZ",
+            Letters = "2346789ABCDGHKMNPRUVWXYZ",
             SessionName = "CaptchaCode",
             FontName = fontName,
             CodeLength = 4


### PR DESCRIPTION
![image](https://github.com/EdiWang/Edi.Captcha.AspNetCore/assets/19531547/aade0dce-0eb4-4a31-84f6-dd94c3fd9567)

* "E\F" is hard to tell in some cases.
* "L" is hard to tell in some cases.


![image](https://github.com/EdiWang/Edi.Captcha.AspNetCore/assets/19531547/8443db6c-72c2-4d3c-9cf2-9de69b5924aa)

![image](https://github.com/EdiWang/Edi.Captcha.AspNetCore/assets/19531547/8d930ec6-53c0-49e7-9ccc-516b3d7a48eb)

![image](https://github.com/EdiWang/Edi.Captcha.AspNetCore/assets/19531547/9d4ec6f9-952a-4867-a123-34095f46a32d)

