### PR TITLE
Update SessionBasedCaptcha.cs to fix #32

### DIFF
--- a/src/Edi.Captcha/Edi.Captcha.csproj
+++ b/src/Edi.Captcha/Edi.Captcha.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.23.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>edi.wang</Company>
     <Authors>Edi Wang</Authors>

--- a/src/Edi.Captcha/SessionBasedCaptcha.cs
+++ b/src/Edi.Captcha/SessionBasedCaptcha.cs
@@ -13,7 +13,7 @@ public class SessionBasedCaptchaOptions
     public FontStyle FontStyle { get; set; } = FontStyle.Regular;
     public string FontName { get; set; }
     public bool DrawLines { get; set; } = true;
-    public string[] BlockedCodes { get; set; }
+    public string[] BlockedCodes { get; set; } = [];
 }
 
 public abstract class SessionBasedCaptcha : ISessionBasedCaptcha
@@ -28,7 +28,6 @@ public abstract class SessionBasedCaptcha : ISessionBasedCaptcha
 
         var captchaCode = GenerateCaptchaCode();
 
-        Options.BlockedCodes ??= [];
         while (Options.BlockedCodes.Contains(captchaCode))
         {
             captchaCode = GenerateCaptchaCode();

--- a/src/Edi.Captcha/SessionBasedCaptcha.cs
+++ b/src/Edi.Captcha/SessionBasedCaptcha.cs
@@ -27,7 +27,6 @@ public abstract class SessionBasedCaptcha : ISessionBasedCaptcha
         EnsureHttpSession(httpSession);
 
         var captchaCode = GenerateCaptchaCode();
-
         while (Options.BlockedCodes.Contains(captchaCode))
         {
             captchaCode = GenerateCaptchaCode();

--- a/src/Edi.Captcha/SessionBasedCaptcha.cs
+++ b/src/Edi.Captcha/SessionBasedCaptcha.cs
@@ -27,6 +27,8 @@ public abstract class SessionBasedCaptcha : ISessionBasedCaptcha
         EnsureHttpSession(httpSession);
 
         var captchaCode = GenerateCaptchaCode();
+
+        Options.BlockedCodes ??= [];
         while (Options.BlockedCodes.Contains(captchaCode))
         {
             captchaCode = GenerateCaptchaCode();


### PR DESCRIPTION
Fix:

```log
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.ArgumentNullException: Value cannot be null. (Parameter 'source')
         at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
         at System.Linq.Enumerable.Contains[TSource](IEnumerable`1 source, TSource value, IEqualityComparer`1 comparer)
         at Edi.Captcha.SessionBasedCaptcha.GenerateCaptchaImageBytes(ISession httpSession, Int32 width, Int32 height, String sessionKeyName)
         at Edi.Captcha.CaptchaImageMiddleware.Invoke(HttpContext context, ISessionBasedCaptcha captcha)
         at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)
fail: MoongladePure.Web.Pages.ErrorModel[0]
      Error: Value cannot be null. (Parameter 'source'), client IP: 192.168.50.187, request id: 00-ca54f09d4ebac770e57b076fcf3d4390-2782c7aef98f987c-00
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.ArgumentNullException: Value cannot be null. (Parameter 'source')
         at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
         at System.Linq.Enumerable.Contains[TSource](IEnumerable`1 source, TSource value, IEqualityComparer`1 comparer)
         at Edi.Captcha.SessionBasedCaptcha.GenerateCaptchaImageBytes(ISession httpSession, Int32 width, Int32 height, String sessionKeyName)
         at Edi.Captcha.CaptchaImageMiddleware.Invoke(HttpContext context, ISessionBasedCaptcha captcha)
         at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)
fail: MoongladePure.Web.Pages.ErrorModel[0]
      Error: Value cannot be null. (Parameter 'source'), client IP: 192.168.50.187, request id: 00-9c82b9db0ade8b7f1399cd785e3e5f1b-3d39c10d6c9c137b-0
```